### PR TITLE
Cerregido Bug Fow

### DIFF
--- a/Map/Assets/Scripts/Fog of war/LOSEntity.cs
+++ b/Map/Assets/Scripts/Fog of war/LOSEntity.cs
@@ -123,4 +123,10 @@ public class LOSEntity : MonoBehaviour {
         }
     }
 
+	public void reveal(){
+		foreach (Renderer R in this.GetComponentsInChildren<Renderer>()) { 
+			R.enabled = true;
+		}
+	}
+
 }

--- a/Map/Assets/Scripts/Fog of war/LOSManager.cs
+++ b/Map/Assets/Scripts/Fog of war/LOSManager.cs
@@ -68,6 +68,8 @@ public class LOSManager : MonoBehaviour {
     float[,] terrainHeightsCache;
     Texture2D losTexture;
 
+	bool revealed = false;
+
     // Used to determine when the user changes a field that requires
     // the texture to be recreated
     private int previewParameterHash = 0;
@@ -115,22 +117,24 @@ public class LOSManager : MonoBehaviour {
     }
 
     void Update() {
-		if (Input.GetKey (KeyCode.R)) {
-			if (this.Terrain.materialType != Terrain.MaterialType.BuiltInStandard){
-				this.Terrain.materialType = Terrain.MaterialType.BuiltInStandard;
-				foreach (var entity in Entities)
-					entity.IsRevealer = true;
-			}
-		}
-		if (Input.GetKey (KeyCode.U)) {
-			this.Terrain.materialTemplate = Resources.Load("Materials/Terrain", typeof(Material)) as Material;
-			this.Terrain.materialType = Terrain.MaterialType.Custom;
-			foreach (var entity in Entities){
-				if (entity.IsAlly != true){
-					entity.IsRevealer = false;
+		if ((Input.GetKey (KeyCode.R) || Input.GetKey (KeyCode.U))) {
+			if (!revealed) {
+				if (this.Terrain.materialType != Terrain.MaterialType.BuiltInStandard) {
+					this.Terrain.materialType = Terrain.MaterialType.BuiltInStandard;
+					foreach (var entity in Entities)
+						entity.reveal ();
 				}
+				revealed = !revealed;
+			} else {
+				this.Terrain.materialTemplate = Resources.Load ("Materials/Terrain", typeof(Material)) as Material;
+				this.Terrain.materialType = Terrain.MaterialType.Custom;
+				foreach (var entity in Entities) {
+					if (entity.IsAlly != true) {
+						entity.RevealState = LOSEntity.RevealStates.Fogged;
+					}
+				}
+				revealed = !revealed;
 			}
-
 		}
 
 #if UNITY_EDITOR
@@ -491,7 +495,7 @@ public class LOSManager : MonoBehaviour {
     public LOSEntity.RevealStates GetRevealFromFOW(Color32 px) {
         if (px.r >= 128) return LOSEntity.RevealStates.Unfogged;
         if (px.g >= 128) return LOSEntity.RevealStates.Fogged;
-        return LOSEntity.RevealStates.Hidden;
+        return LOSEntity.RevealStates.Fogged;
     }
     public LOSEntity.RevealStates IsVisible(Vector2 pos) {
         return GetRevealFromFOW(GetFOWColor(pos));


### PR DESCRIPTION
Los enemigos dentro de territorio no explorado no se ven. Tambien se ha
corregido que cuando se explora el mapa con la tecla 'r' (ahora tambien
con la 'u') y se vuelve al estado anterior (ahora con ambas teclas) los
enemigos y recursos no exploran territorio. No obstante, el controlador
del fow detecta que los ha visto, por lo tanto los edificios y recursos
se veran.